### PR TITLE
Discard transaction item if item_id is nil

### DIFF
--- a/app/models/concerns/transactionable.rb
+++ b/app/models/concerns/transactionable.rb
@@ -3,7 +3,7 @@ module Transactionable
 
   included do
     has_many :transaction_items, as: :transactionable, dependent: :destroy
-    accepts_nested_attributes_for :transaction_items, allow_destroy: true
+    accepts_nested_attributes_for :transaction_items, allow_destroy: true, reject_if: proc { |attributes| attributes['item_id'].blank? }
   end
 
   private


### PR DESCRIPTION
Fixes `NoMethodError - undefined method`current_rate' for nil:NilClass` while creating donation record.
