### PR TITLE
Adjust cash receipt spacing on server

### DIFF
--- a/app/views/donations/cash_receipt.html.haml
+++ b/app/views/donations/cash_receipt.html.haml
@@ -11,8 +11,6 @@
 %br
 %br
 %br
-%br
-%br
 
 .pull-left{style: "width: 300px;"}
 


### PR DESCRIPTION
Spacing at the top was pushing content to second page. Fixed.
