### PR TITLE
Add donation actions for non-kind donations

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,3 +25,7 @@ Style/HashTransformKeys:
 # Enable when we are on ruby 2.4
 Style/HashTransformValues:
   Enabled: false
+
+# Too restrictive
+Metrics/ClassLength:
+  Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ before_script:
 #   -in bal_asha_deploy_id_rsa.enc -out ~\/.ssh/id_rsa -d
 script:
   - bundle exec rubocop -D
+  - bundle exec rake db:migrate
   - bundle exec rake test
 services:
   - mysql

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -372,4 +372,8 @@ $(document).ready(function() {
   $('#audit_search .text-filter').blur(function () {
     $('#audit_search').submit();
   });
+
+  $('#donation-acknowledgements .daterangepicker').on('hide.daterangepicker', function (ev, picker) {
+    $('#donation-acknowledgements').submit();
+  });
 });

--- a/app/controllers/donation_actions_controller.rb
+++ b/app/controllers/donation_actions_controller.rb
@@ -1,0 +1,17 @@
+class DonationActionsController < ApplicationController
+  def update
+    donation = Donation.find(params[:donation_id])
+
+    attrs_to_update = {}
+    attrs_to_update[:receipt_mode_cd] = params[:receipt_mode_cd].to_i if params[:receipt_mode_cd].present?
+    attrs_to_update[:thank_you_mode_cd] = params[:thank_you_mode_cd].to_i if params[:thank_you_mode_cd].present?
+
+    if donation.donation_actions.update(attrs_to_update)
+      flash[:notice] = "Updated successfully!"
+      render json: {}, status: :ok
+    else
+      flash[:alert] = "Something went wrong!"
+      render json: {}, status: :unprocessable_entity
+    end
+  end
+end

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -64,4 +64,18 @@ class ReportsController < ApplicationController
     @total_kind_donations = ReportsService.total_kind_donations(start_date, end_date, params[:category_id])
   end
 
+  def donation_acknowledgements
+    if params[:daterange].present?
+      start_date_string, end_date_string = params[:daterange].split(" - ")
+      @start_date = DateTime.parse(start_date_string)
+      @end_date = DateTime.parse(end_date_string).end_of_day
+    else
+      @start_date = (Date.today - 1.month).beginning_of_month.to_datetime
+      @end_date = Date.today.end_of_month.to_datetime.end_of_day
+    end
+
+    @daterange_field_text = "#{l(@start_date, format: :formal)} - #{l(@end_date, format: :formal)}"
+    @donations = Donation.joins(:donation_actions).eager_load(:donor, :donation_actions)
+                         .where(date: @start_date..@end_date).order(date: :asc)
+  end
 end

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -4,6 +4,7 @@ class WelcomeController < ApplicationController
     @donors = Donor.upcoming_birthdays
     @needs = Item.needs
     @call_for_actions = CallForAction.pending
+    @donations = Donation.unacknowledged
   end
 
 end

--- a/app/models/donation_actions.rb
+++ b/app/models/donation_actions.rb
@@ -1,0 +1,21 @@
+# == Schema Information
+#
+# Table name: donation_actions
+#
+#  id                :integer          not null, primary key
+#  donation_id       :integer          not null
+#  receipt_mode_cd   :integer          default(0), not null
+#  thank_you_mode_cd :integer          default(0), not null
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#
+
+class DonationActions < ActiveRecord::Base
+
+  belongs_to :donation
+
+  enum receipt_mode_cd: { not_sent: 0, no: 1, yes: 2 }
+  enum thank_you_mode_cd: { pending: 0, na: 1, call: 2, whatsapp: 3, email: 4 }
+
+  validates_presence_of :donation_id, :receipt_mode_cd, :thank_you_mode_cd
+end

--- a/app/views/reports/donation_acknowledgements.html.haml
+++ b/app/views/reports/donation_acknowledgements.html.haml
@@ -1,0 +1,28 @@
+.row
+  .col-md-12
+    = form_tag reports_donation_acknowledgements_path, method: :get, class: "form-inline", id: "donation-acknowledgements" do
+      = text_field_tag :daterange, @daterange_field_text, class: "daterangepicker"
+
+%br
+.row
+  .col-md-12
+    %table.table.table-responsive
+      %thead
+        %tr
+          %th.col-md-3 Date
+          %th.col-md-3 Donor
+          %th.col-md-3 Receipt Status
+          %th.col-md-3 Thank You Status
+      %tbody
+        - @donations.each do |donation|
+          - donor = donation.donor
+          - actions = donation.donation_actions
+          - if donor
+            %tr
+              %td= link_to l(donation.date, format: :formal), donation_path(donation)
+              %td= donor.full_name
+              %td= actions.receipt_mode_cd == "not_sent" ? "" : actions.receipt_mode_cd.upcase
+              %td= actions.thank_you_mode_cd == "pending" ? "" : actions.thank_you_mode_cd.upcase
+          - else
+            %tr
+              %td{colspan: 4} Donor Deleted

--- a/app/views/shared/_nav_bar.html.haml
+++ b/app/views/shared/_nav_bar.html.haml
@@ -39,6 +39,7 @@
                 %a{href: reports_audit_path } Audit Report
                 %a{href: reports_top_donors_path } Top Donors
                 %a{href: reports_total_kind_donations_path } Total Kind Donations
+                %a{href: reports_donation_acknowledgements_path } Donation Acknowledgements
               / %li.divider{:role => "separator"}
               / %li
               /   %a{:href => "#"} Separated link

--- a/app/views/welcome/index.html.haml
+++ b/app/views/welcome/index.html.haml
@@ -74,3 +74,41 @@
                   %td= link_to l(call_for_action.date_of_action, format: :formal), donor_call_for_action_path(donor, call_for_action)
                   %td= link_to donor.full_name, donor_path(donor)
                   %td= call_for_action.remarks
+
+.row
+  .col-md-12
+    .panel.panel-default
+      .panel-heading
+        %h3.panel-title Unacknowledged Donations
+      .panel-body
+        - if @donations.empty?
+          %p All donations acknowledged
+        - else
+          %table.table
+            %thead
+              %tr
+                %th.col-md-2 Date
+                %th.col-md-2 Donor
+                %th.col-md-4 Receipt Sent?
+                %th.col-md-4 Thanked Via
+            %tbody
+              - @donations.each do |donation|
+                - donor = donation.donor
+                - actions = donation.donation_actions
+                %tr
+                  %td= link_to l(donation.date, format: :formal), donation_path(donation)
+                  %td= donor.full_name
+                  %td
+                    - DonationActions.receipt_mode_cds.except(:not_sent).each do |label, value|
+                      = link_to label, donation_donation_actions_path(donation_id: donation.id, receipt_mode_cd: value), method: :patch, data: { confirm: "Are you sure?" }, remote: true, class: "btn btn-#{actions.receipt_mode_cd == label ? 'primary' : 'default'} receipt-mode-link"
+                  %td
+                    - DonationActions.thank_you_mode_cds.except(:pending).each do |label, value|
+                      = link_to label, donation_donation_actions_path(donation_id: donation.id, thank_you_mode_cd: value), method: :patch, data: { confirm: "Are you sure?" }, remote: true, class: "btn btn-#{actions.thank_you_mode_cd == label ? 'primary' : 'default'} thank-you-mode-link"
+
+
+:javascript
+  $(document).ready(function() {
+    $(".receipt-mode-link, .thank-you-mode-link").on("ajax:complete", function() {
+      location.reload();
+    });
+  });

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,7 @@ Rails.application.routes.draw do
   resources :donations do
     member { get :print }
     resources :comments, only: [:create, :destroy]
+    resource :donation_actions, only: [:update]
   end
 
   resources :categories
@@ -35,6 +36,7 @@ Rails.application.routes.draw do
     get :audit, controller: 'reports'
     get :top_donors, controller: 'reports'
     get :total_kind_donations, controller: 'reports'
+    get :donation_acknowledgements, controller: 'reports'
   end
 
   root 'welcome#index'

--- a/db/migrate/20200525071045_create_donation_actions.rb
+++ b/db/migrate/20200525071045_create_donation_actions.rb
@@ -1,0 +1,13 @@
+class CreateDonationActions < ActiveRecord::Migration
+  def change
+    create_table :donation_actions do |t|
+      t.references :donation, null: false
+      t.integer :receipt_mode_cd, default: 0, null: false
+      t.integer :thank_you_mode_cd, default: 0, null: false
+
+      t.timestamps null: false
+    end
+
+    add_index :donation_actions, [:receipt_mode_cd, :thank_you_mode_cd]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151003111748) do
+ActiveRecord::Schema.define(version: 20200525071045) do
 
   create_table "call_for_actions", force: true do |t|
     t.datetime "date_of_action"
@@ -57,6 +57,16 @@ ActiveRecord::Schema.define(version: 20151003111748) do
 
   add_index "disbursements", ["deleted_at"], name: "index_disbursements_on_deleted_at", using: :btree
   add_index "disbursements", ["person_id"], name: "index_disbursements_on_person_id", using: :btree
+
+  create_table "donation_actions", force: true do |t|
+    t.integer  "donation_id",                   null: false
+    t.integer  "receipt_mode_cd",   default: 0, null: false
+    t.integer  "thank_you_mode_cd", default: 0, null: false
+    t.datetime "created_at",                    null: false
+    t.datetime "updated_at",                    null: false
+  end
+
+  add_index "donation_operations", ["receipt_mode_cd", "thank_you_mode_cd"], name: "index_donation_operations_on_receipt_mode_cd_and_thank_you_mode_cd", using: :btree
 
   create_table "donations", force: true do |t|
     t.datetime "date"

--- a/test/controllers/donations_actions_controller_test.rb
+++ b/test/controllers/donations_actions_controller_test.rb
@@ -1,0 +1,19 @@
+class DonationActionsControllerTest < ActionController::TestCase
+
+  def setup
+    sign_in people(:nitish)
+  end
+
+  test "should update receipt_mode_cd and thank_you_mode_cd" do
+    donation = Donation.create!(date: Date.today, person_id: Person.first.id,
+                                donor_id: Donor.first.id, amount: 1000, receipt_number: "BAT76554", type_cd: 0)
+
+    patch :update, donation_id: donation.id, receipt_mode_cd: "2", thank_you_mode_cd: "3"
+
+    assert_response :success
+    actions = donation.reload.donation_actions
+    assert_equal 2, actions.read_attribute(:receipt_mode_cd)
+    assert_equal 3, actions.read_attribute(:thank_you_mode_cd)
+  end
+
+end

--- a/test/models/donation_test.rb
+++ b/test/models/donation_test.rb
@@ -203,4 +203,30 @@ class DonationTest < ActiveSupport::TestCase
     refute_empty donation.receipt_number
   end
 
+  test "donation_actions record is created for non-kind donations" do
+    donation = Donation.new(date: Date.today, person_id: Person.first.id,
+                            donor_id: Donor.first.id, amount: 1000, receipt_number: "BAT76554", type_cd: 0)
+    donation.save!
+    refute_nil donation.donation_actions
+
+    milk = items(:milk)
+    donation = Donation.new(date: Date.today, person_id: Person.first.id,
+                            donor_id: Donor.first.id, amount: 1000, receipt_number: "BAT76554", type_cd: 1)
+    donation.transaction_items.build(item_id: milk.id, quantity: 10)
+    donation.save!
+    assert_nil donation.donation_actions
+  end
+
+  test '.unacknowledged returns donations which have associated donation_actions and are not acknowledged by both thank you and receipt in oldest first order' do
+    donations(:kind)
+    donations(:cash).create_donation_actions!(receipt_mode_cd: 0, thank_you_mode_cd: 0)
+    donations(:neft).create_donation_actions!(receipt_mode_cd: 1, thank_you_mode_cd: 0)
+    donations(:cheque).create_donation_actions!(receipt_mode_cd: 0, thank_you_mode_cd: 1)
+    donations(:online).create_donation_actions!(receipt_mode_cd: 2, thank_you_mode_cd: 3)
+
+    donations = Donation.unacknowledged
+
+    assert_equal 3, donations.size
+    assert_equal ['neft', 'cheque', 'cash'], donations.map(&:type_cd)
+  end
 end


### PR DESCRIPTION
- Add a model for tracking status of receipt sent and thank you
- Show those donations on the dashboard for which either of these fields
are not set
(Assumption is we won't populate donation actions for past donations)
- Add a report for donation actions with daterange filter