### PR TITLE
Add auto receipt_number generation for neft and online donations

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -29,3 +29,7 @@ Style/HashTransformValues:
 # Too restrictive
 Metrics/ClassLength:
   Enabled: false
+
+# Ignore RSpec methods - https://stackoverflow.com/a/41689335
+Metrics/BlockLength:
+  ExcludedMethods: ['describe', 'context']

--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,7 @@ gem 'kaminari'
 gem 'kaminari-bootstrap', '~> 3.0.1'
 gem 'select2-rails'
 gem 'faker'
+gem 'timecop'
 
 gem 'rollbar', '~> 2.15.5'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -282,6 +282,7 @@ GEM
     thor (0.20.3)
     thread_safe (0.3.6)
     tilt (1.4.1)
+    timecop (0.9.5)
     turbolinks (2.5.3)
       coffee-rails
     tzinfo (1.2.7)
@@ -344,6 +345,7 @@ DEPENDENCIES
   sass-rails (~> 4.0.3)
   select2-rails
   simple_form
+  timecop
   turbolinks
   uglifier (>= 1.3.0)
   web-console (~> 2.0)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -246,7 +246,7 @@ $(document).ready(function() {
   var donationTypeChanged = function() {
     var type_val = $("#donation_type_cd").val();
 
-    if(type_val == "cash") {
+    if (type_val == "cash" || type_val == "cheque") {
       $("#items").addClass("hidden");
       $(".donation_payment_details").removeClass("hidden");
       $(".donation_amount").removeClass("hidden");
@@ -256,11 +256,12 @@ $(document).ready(function() {
       $(".donation_payment_details").addClass("hidden");
       $("#items").removeClass("hidden");
       $(".donation_receipt_number").addClass("hidden");
-    } else if(type_val == "cheque" || type_val == "neft") {
+    } else if(type_val == "neft" || type_val == "online") {
       $("#items").addClass("hidden");
-      $(".donation_amount").removeClass("hidden");
       $(".donation_payment_details").removeClass("hidden");
-      $(".donation_receipt_number").removeClass("hidden");
+      $(".donation_amount").removeClass("hidden");
+      $(".new_donation .donation_receipt_number").addClass("hidden");
+      $(".edit_donation .donation_receipt_number").removeClass("hidden");
     }
   }
 

--- a/spec/factories/donations_factory.rb
+++ b/spec/factories/donations_factory.rb
@@ -1,0 +1,37 @@
+FactoryBot.define do
+  factory :donation, class: Donation do
+    date { Time.now }
+    donor_id { create(:donor).id }
+    person_id { create(:person).id }
+    thank_you_sent { true }
+    category { 0 }
+
+    trait :cash do
+      type_cd { 0 }
+      amount { 100_000 }
+      receipt_number { Faker::Number.number(10) }
+    end
+
+    trait :cheque do
+      type_cd { 2 }
+      amount { 100_000 }
+      receipt_number { Faker::Number.number(10) }
+      payment_details { Faker::Lorem.sentence }
+    end
+
+    trait :neft do
+      type_cd { 3 }
+      amount { 100_000 }
+    end
+
+    trait :online do
+      type_cd { 4 }
+      amount { 100_000 }
+    end
+
+    trait :kind do
+      type_cd { 1 }
+      transaction_items { [create(:transaction_item, :donation)] }
+    end
+  end
+end

--- a/spec/factories/donors_factory.rb
+++ b/spec/factories/donors_factory.rb
@@ -1,0 +1,24 @@
+FactoryBot.define do
+  factory :donor, class: Donor do
+    first_name { Faker::Name.first_name }
+    last_name { Faker::Name.last_name }
+    gender { Donor.genders.values.sample }
+    date_of_birth { Faker::Date.birthday }
+    donor_type { 0 }
+    level { 0 }
+    trust_no {}
+    mobile {}
+    telephone {}
+    email { Faker::Internet.email }
+    address { Faker::Address.street_address }
+    city {}
+    pincode {}
+    state {}
+    solicit { true }
+    country_code { 'IN' }
+    contact_frequency { 1 }
+    preferred_communication_mode { 1 }
+    status { 0 }
+    remarks {}
+  end
+end

--- a/spec/factories/items_factory.rb
+++ b/spec/factories/items_factory.rb
@@ -1,4 +1,14 @@
 FactoryBot.define do
+  factory :item do
+    name { Faker::Lorem.word }
+    remarks { Faker::Lorem.sentence }
+    current_rate { Faker::Number.number(3) }
+    unit             { 'kg' }
+    minimum_quantity { 10 }
+    category_id      { create(:category).id }
+    stock_quantity   { 0 }
+  end
+
   factory :rice, class: Item do
     name { 'Rice' }
     remarks { 'kolam' }

--- a/spec/factories/transaction_items_factory.rb
+++ b/spec/factories/transaction_items_factory.rb
@@ -1,0 +1,17 @@
+FactoryBot.define do
+  factory :transaction_item, class: TransactionItem do
+    item_id { create(:item).id }
+    rate { 50 }
+    quantity { 10 }
+
+    trait :donation do
+      transactionable_type { 'Donation' }
+      transactionable_id { SecureRandom.uuid }
+    end
+
+    trait :disbursement do
+      transactionable_type { 'Disbursement' }
+      transactionable_id { SecureRandom.uuid }
+    end
+  end
+end

--- a/spec/models/donation_spec.rb
+++ b/spec/models/donation_spec.rb
@@ -3,4 +3,141 @@ require_relative 'concerns/transactionable_spec'
 
 RSpec.describe Donation, type: :model do
   it_behaves_like 'a stock increaser', Donation, date: Date.today, donor_id: rand(1..100), type_cd: Donation.type_cds[:kind], person_id: rand(1..100)
+
+  describe 'receipt number' do
+    shared_examples 'a series based receipt number based on current financial year' do
+      before do
+        Timecop.freeze(Time.local(2022, 1, 1))
+      end
+
+      after do
+        Timecop.return
+      end
+
+      context 'when there aren\'t any donations for current FY series' do
+        it 'generates a receipt number starting the series' do
+          donation = build(:donation, donation_type)
+          donation.save
+
+          expect(donation.errors.full_messages).to eq([])
+          expect(donation.receipt_number).to eq('BAT/Receipt/Electronic/2021-22/0001')
+        end
+      end
+
+      context 'when there are donations for current FY series' do
+        before do
+          create(:donation, donation_type).update!(receipt_number: 'BAT/Receipt/Electronic/2021-22/0003')
+          create(:donation, donation_type).update!(receipt_number: 'BAT/Receipt/Electronic/2020-21/0006')
+          create(:donation, donation_type).update!(receipt_number: 'BAT/Receipt/Electronic/2021-22/0001')
+          create(:donation, donation_type).update!(receipt_number: 'BAT/Receipt/Electronic/2022-23/0005')
+        end
+
+        it 'generates next receipt number in the series' do
+          donation = build(:donation, donation_type)
+          donation.save
+
+          expect(donation.errors.full_messages).to eq([])
+          expect(donation.receipt_number).to eq('BAT/Receipt/Electronic/2021-22/0004')
+        end
+      end
+
+      context 'when the current date is after March but before next calendar year' do
+        before do
+          Timecop.freeze(Time.local(2022, 4, 1))
+        end
+
+        after do
+          Timecop.return
+        end
+
+        it 'generates next receipt number in the series' do
+          donation = build(:donation, donation_type)
+          donation.save
+
+          expect(donation.errors.full_messages).to eq([])
+          expect(donation.receipt_number).to eq('BAT/Receipt/Electronic/2022-23/0001')
+        end
+      end
+    end
+
+    context 'when donation is made in cash' do
+      context 'when receipt number is not present' do
+        it 'fails validation' do
+          donation = build(:donation, :cash, receipt_number: nil)
+          donation.save
+
+          expect(donation.errors.full_messages).to contain_exactly('Receipt number can\'t be blank')
+        end
+      end
+
+      context 'when receipt number is present' do
+        it 'saves the record with the specified receipt number' do
+          donation = build(:donation, :cash, receipt_number: 'rec1234')
+          donation.save
+
+          expect(donation.errors.full_messages).to eq([])
+          expect(donation.receipt_number).to eq('rec1234')
+        end
+      end
+    end
+
+    context 'when donation is made by cheque' do
+      context 'when receipt number is not present' do
+        it 'fails validation' do
+          donation = build(:donation, :cheque, receipt_number: nil)
+          donation.save
+
+          expect(donation.errors.full_messages).to contain_exactly('Receipt number can\'t be blank')
+        end
+      end
+
+      context 'when receipt number is present' do
+        it 'saves the record with the specified receipt number' do
+          donation = build(:donation, :cheque, receipt_number: 'rec1234')
+          donation.save
+
+          expect(donation.errors.full_messages).to eq([])
+          expect(donation.receipt_number).to eq('rec1234')
+        end
+      end
+    end
+
+    context 'when donation is in kind' do
+      it 'generates a receipt number and saved the record with it' do
+        donation = build(:donation, :kind)
+        donation.save
+
+        expect(donation.errors.full_messages).to eq([])
+        expect(donation.receipt_number).to start_with('KIND')
+      end
+    end
+
+    context 'when donation is made online' do
+      let(:donation_type) { :online }
+
+      it 'auto generates receipt number that uses a financial year specific series' do
+        donation = build(:donation, donation_type)
+        donation.save
+
+        expect(donation.errors.full_messages).to eq([])
+        expect(donation.receipt_number).to start_with('BAT/Receipt/Electronic/')
+      end
+
+      include_examples 'a series based receipt number based on current financial year'
+    end
+
+    context 'when donation is made by NEFT' do
+      let(:donation_type) { :neft }
+
+      it 'auto generates receipt number that uses a financial year specific series' do
+        donation = build(:donation, donation_type)
+        donation.save
+
+        expect(donation.errors.full_messages).to eq([])
+        expect(donation.receipt_number).to start_with('BAT/Receipt/Electronic/')
+      end
+
+      include_examples 'a series based receipt number based on current financial year'
+    end
+  end
 end


### PR DESCRIPTION
Requirement:
From 1st April 2022 we would like to auto give the numbers to receipt

BAT/Receipt/Electronic/2022-23/0001

This number changes financial year wise i.e. BAT/Receipt/Electronic/2023-24/0001

The cheque / cash receipts will remain manual so we need to have the column of Receipt number vacant.
Note: Kind is anyway automatic